### PR TITLE
Trying to update replies on tab changes

### DIFF
--- a/pkg/web/src/pages/browser/[...pathes]/components/Revision/index.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/Revision/index.tsx
@@ -85,11 +85,8 @@ export const Revision = (props: {
     await api.browser.works
       ._workId(props.workId)
       .revisions.$post({ body: { uploadFile: file, projectId: props.projectId } })
-      .catch(onErr)
 
     const revisionRes = await api.browser.works._workId(props.workId).revisions.$get()
-
-    if (!revisionRes) return
 
     updateApiWholeData(
       'revisionsList',

--- a/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
@@ -71,9 +71,11 @@ export const StreamBar = (props: {
 
     updateApiWholeData(
       'messagesList',
-      apiWholeData.messagesList.map((m) =>
-        m.revisionId === messageRes.revisionId ? messageRes : m
-      )
+      apiWholeData.messagesList.some((d) => d.revisionId === messageRes.revisionId)
+        ? apiWholeData.messagesList.map((m) =>
+            m.revisionId === messageRes.revisionId ? messageRes : m
+          )
+        : [...apiWholeData.messagesList, messageRes]
     )
 
     setContent('')
@@ -92,14 +94,18 @@ export const StreamBar = (props: {
         .messages._messageId(messageId)
         .replies.post({ body: { content, userName } })
 
-      const replyRes = await api.browser.works
+      const messageRes = await api.browser.works
         ._workId(props.workId)
         .revisions._revisionId(props.revision.id)
         .messages.$get()
 
       updateApiWholeData(
         'messagesList',
-        apiWholeData.messagesList.map((m) => (m.revisionId === replyRes.revisionId ? replyRes : m))
+        apiWholeData.messagesList.some((d) => d.revisionId === messageRes.revisionId)
+          ? apiWholeData.messagesList.map((m) =>
+              m.revisionId === messageRes.revisionId ? messageRes : m
+            )
+          : [...apiWholeData.messagesList, messageRes]
       )
     },
     [content]

--- a/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
@@ -58,6 +58,12 @@ export const StreamBar = (props: {
       .post({ body: { content, userName } })
       .catch(onErr)
 
+    const revisionRess = await api.browser.works._workId(props.workId).revisions.$get()
+    updateApiWholeData(
+      'revisionsList',
+      apiWholeData.revisionsList.map((r) => (r.workId === revisionRess.workId ? revisionRess : r))
+    )
+
     const messageRes = await api.browser.works
       ._workId(props.workId)
       .revisions._revisionId(props.revision.id)
@@ -90,9 +96,6 @@ export const StreamBar = (props: {
         ._workId(props.workId)
         .revisions._revisionId(props.revision.id)
         .messages.$get()
-        .catch(onErr)
-
-      if (!replyRes) return
 
       updateApiWholeData(
         'messagesList',

--- a/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/components/StreamBar/index.tsx
@@ -101,11 +101,9 @@ export const StreamBar = (props: {
 
       updateApiWholeData(
         'messagesList',
-        apiWholeData.messagesList.some((d) => d.revisionId === messageRes.revisionId)
-          ? apiWholeData.messagesList.map((m) =>
-              m.revisionId === messageRes.revisionId ? messageRes : m
-            )
-          : [...apiWholeData.messagesList, messageRes]
+        apiWholeData.messagesList.map((m) =>
+          m.revisionId === messageRes.revisionId ? messageRes : m
+        )
       )
     },
     [content]

--- a/pkg/web/src/pages/browser/[...pathes]/index.page.tsx
+++ b/pkg/web/src/pages/browser/[...pathes]/index.page.tsx
@@ -39,7 +39,7 @@ const ProjectPage = () => {
         messages:
           projectApiData.messages?.filter((message) => p.messageIds?.includes(message.id)) ?? [],
       })) ?? [],
-    [projectApiData]
+    [projectApiData?.revisions, projectApiData?.messages, currentProject?.openedTabId]
   )
 
   if (!projectApiData || !currentProject) return <Fetching error={error} />

--- a/pkg/web/src/pages/browser/[...pathes]/useFetch.ts
+++ b/pkg/web/src/pages/browser/[...pathes]/useFetch.ts
@@ -58,7 +58,6 @@ export const useFetch = (
           )
         : [...apiWholeData.revisionsList, revisionsData]
     )
-    updateMessage(revisionsData)
   }, [revisionsRes.data])
 
   useEffect(() => {

--- a/pkg/web/src/pages/browser/[...pathes]/useFetch.ts
+++ b/pkg/web/src/pages/browser/[...pathes]/useFetch.ts
@@ -58,7 +58,7 @@ export const useFetch = (
           )
         : [...apiWholeData.revisionsList, revisionsData]
     )
-  }, [revisionsRes.data])
+  }, [revisionsRes.data, currentProject?.openedTabId])
 
   useEffect(() => {
     const messageRes = async () => {

--- a/pkg/web/src/pages/browser/[...pathes]/usePage.ts
+++ b/pkg/web/src/pages/browser/[...pathes]/usePage.ts
@@ -87,11 +87,7 @@ export const usePage = () => {
     const revisions = apiWholeData.revisionsList.find(
       (d) => d.workId === currentProject.openedTabId
     )?.revisions
-
-    const messages = apiWholeData.messagesList
-      .filter((m) => revisions?.some((revision) => revision.id === m.revisionId))
-      ?.flatMap((m) => m.messages)
-
+    const messages = apiWholeData.messagesList.flatMap((m) => m.messages)
     return (
       data &&
       desks && {


### PR DESCRIPTION
タブを変えたときにapiWholeDataの更新は走っているけれども、
リプライ送信時に一番左端のapiWholeData.messageList を使用してしまう。